### PR TITLE
 Remove OS-specific checks for installation step

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,14 +32,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install rust
+      shell: bash
       run:
-        shell: |
-          if hash rustup 2>/dev/null; then
-            rustup update
-          else
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            mv $HOME/.cargo/bin/* /usr/local/bin
-          fi
+        if hash rustup 2>/dev/null; then
+          rustup update
+        else
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          mv $HOME/.cargo/bin/* /usr/local/bin
+        fi
     - name: Check rust version
       run: rustc -Vv && cargo -V
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,13 +32,13 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install rust
-      if: matrix.os == 'macOS-latest'
       run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        mv $HOME/.cargo/bin/* /usr/local/bin
-    - name: Update rust
-      if: matrix.os != 'macOS-latest'
-      run: rustup update
+        if hash rustup 2>/dev/null; then
+          rustup update
+        else
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          mv $HOME/.cargo/bin/* /usr/local/bin
+        fi
     - name: Check rust version
       run: rustc -Vv && cargo -V
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,13 +32,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install rust
-      run: |
-        if hash rustup 2>/dev/null; then
-          rustup update
-        else
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          mv $HOME/.cargo/bin/* /usr/local/bin
-        fi
+      run:
+        shell: |
+          if hash rustup 2>/dev/null; then
+            rustup update
+          else
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            mv $HOME/.cargo/bin/* /usr/local/bin
+          fi
     - name: Check rust version
       run: rustc -Vv && cargo -V
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install rust
       shell: bash
-      run:
+      run: |
         if hash rustup 2>/dev/null; then
           rustup update
         else


### PR DESCRIPTION
Just downloads rustup if it doesn't exist, rather than hardcoding a
check for the MacOS case.